### PR TITLE
ci: remove usage of secrets.GCP_DOCS_CREDENTIAL_JSON

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,7 @@ name: Launch benchmarks and create report
 permissions:
   actions: write  # Need write for workflow_dispatch event
   contents: read
+  id-token: "write"
 
 on:
   workflow_dispatch:
@@ -35,7 +36,9 @@ jobs:
       - name: Setup Google Auth 🔧
         uses: "google-github-actions/auth@v1"
         with:
-          credentials_json: "${{ secrets.GCP_DOCS_CREDENTIAL_JSON }}"
+          # yamllint disable-line rule:line-length
+          workload_identity_provider: "projects/370784745717/locations/global/workloadIdentityPools/github/providers/github"
+          service_account: "github-actions@github-400420.iam.gserviceaccount.com"
 
       - name: Upload benchmark file to GCP 🚀
         uses: google-github-actions/upload-cloud-storage@v1.0.3

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -3,6 +3,7 @@ name: Create report from latest benchmark workflows
 permissions:
   actions: write
   contents: read
+  id-token: write
 
 on:
   workflow_dispatch:
@@ -52,7 +53,9 @@ jobs:
       - name: Setup Google Auth 🔧
         uses: "google-github-actions/auth@v1"
         with:
-          credentials_json: "${{ secrets.GCP_DOCS_CREDENTIAL_JSON }}"
+          # yamllint disable-line rule:line-length
+          workload_identity_provider: "projects/370784745717/locations/global/workloadIdentityPools/github/providers/github"
+          service_account: "github-actions@github-400420.iam.gserviceaccount.com"
 
       - name: Upload benchmark file to GCP 🚀
         uses: google-github-actions/upload-cloud-storage@v1.0.3


### PR DESCRIPTION
This replaces GCP authentication from Service Account Key to Workload
Identity Federation

Fixes MRGFY-2694